### PR TITLE
Only use jest-puppeteer

### DIFF
--- a/steps/let_it_sink_is_verified_frontend.yml
+++ b/steps/let_it_sink_is_verified_frontend.yml
@@ -68,5 +68,4 @@ githubActions:
   frontend:
     capabilities:
       - jest-puppeteer
-      - "puppeteer@18.1.0"
     testFile: "is_verified_frontend.test.js"


### PR DESCRIPTION
We don't need to add both now, since it's been added as a capability.